### PR TITLE
Added Integration Tests For Log In Endpoint

### DIFF
--- a/TodoAPIAssignement.API.Tests/IntegrationTests/HelperMethods/JsonParsingHelperMethods.cs
+++ b/TodoAPIAssignement.API.Tests/IntegrationTests/HelperMethods/JsonParsingHelperMethods.cs
@@ -1,0 +1,14 @@
+﻿using System.Text.Json;
+
+namespace TodoAPIAssignement.API.Tests.IntegrationTests.HelperMethods;
+
+internal class JsonParsingHelperMethods
+{
+    internal static async Task<string?> GetSingleStringValueFromBody(HttpResponseMessage response, string key)
+    {
+        string? responseBody = await response.Content.ReadAsStringAsync();
+        var keyValue = JsonSerializer.Deserialize<Dictionary<string, string>>(responseBody);
+        keyValue!.TryGetValue(key, out string? value);
+        return value;
+    }
+}

--- a/TodoAPIAssignement.API.Tests/IntegrationTests/HelperMethods/ResetDatabaseHelperMethods.cs
+++ b/TodoAPIAssignement.API.Tests/IntegrationTests/HelperMethods/ResetDatabaseHelperMethods.cs
@@ -4,7 +4,7 @@ namespace TodoAPIAssignement.API.Tests.IntegrationTests.HelperMethods;
 
 internal class ResetDatabaseHelperMethods
 {
-    public static async Task ResetNoSqlEmailDatabase()
+    internal static async Task ResetNoSqlEmailDatabase()
     {
         string cosmosDbConnectionString = "AccountEndpoint=https://localhost:8081/;AccountKey=C2y6yDjf5/R+ob0N8A7Cgv30VRDJIWEHLM+4QDU5DE2nQ9nDuVTqobD4b8mGGyPMbIZnqyMsEcaGQy67XIw/Jw==";
 

--- a/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
+++ b/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
@@ -1,6 +1,8 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using TodoAPIAssignment.API.Models.RequestModels;
 using TodoAPIAssignment.AuthenticationLibrary;
+using TodoAPIAssignment.AuthenticationLibrary.Enums;
+using TodoAPIAssignment.AuthenticationLibrary.Models;
 
 namespace TodoAPIAssignment.API.Controllers;
 
@@ -20,19 +22,19 @@ public class AuthenticationController : ControllerBase
     {
         try
         {
-            string result = await _authenticationDataAccess.SignUpAsync(signUpRequestModel.Username!, 
+            AuthenticationResult result = await _authenticationDataAccess.SignUpAsync(signUpRequestModel.Username!, 
                 signUpRequestModel.Password!, signUpRequestModel.Email!)!;
             
-            if(result == "DuplicateUsernameError")
+            if(result.ErrorCode == ErrorCode.DuplicateUsername)
                 return BadRequest(new {ErrorMessage = "DuplicateUsernameError"});
-            else if (result == "DuplicateEmailError")
+            else if (result.ErrorCode == ErrorCode.DuplicateEmail)
                 return BadRequest(new { ErrorMessage = "DuplicateEmailError" });
 
-            return Ok(new { Token = result });
+            return Ok(new { Token = result.Token });
         }
         catch (Exception)
         {
-            return StatusCode(500, "Internal Server Error"); ;
+            return StatusCode(500, new { ErrorMessage = "InternalServerError" }); ;
         }
     }
 
@@ -41,16 +43,16 @@ public class AuthenticationController : ControllerBase
     {
         try
         {
-            string result = await _authenticationDataAccess.LogInAsync(logInRequestModel.Username!, logInRequestModel.Password!)!;
+            AuthenticationResult result = await _authenticationDataAccess.LogInAsync(logInRequestModel.Username!, logInRequestModel.Password!)!;
 
-            if (result == "InvalidCredentials")
+            if (result.ErrorCode == ErrorCode.InvalidCredentials)
                 return BadRequest(new { ErrorMessage = "InvalidCredentialsError" });
 
-            return Ok(new { Token = result });
+            return Ok(new { Token = result.Token });
         }
         catch (Exception)
         {
-            return StatusCode(500, "Internal Server Error"); ;
+            return StatusCode(500, new { ErrorMessage = "InternalServerError" }); ;
         }
     }
 }

--- a/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/LogInUnitTests.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/LogInUnitTests.cs
@@ -3,6 +3,8 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
 using NSubstitute.ReturnsExtensions;
+using TodoAPIAssignment.AuthenticationLibrary.Enums;
+using TodoAPIAssignment.AuthenticationLibrary.Models;
 
 namespace TodoAPIAssignment.AuthenticationLibrary.Tests.UnitTests;
 
@@ -43,11 +45,11 @@ public class LogInUnitTests
         _config["Jwt:Audience"].ReturnsNull();
 
         //Act
-        string? result = await _authenticationDataAccess.LogInAsync("konstantinos", "password")!;
+        AuthenticationResult? result = await _authenticationDataAccess.LogInAsync("konstantinos", "password")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().Be("DatabaseError");
+        result.ErrorCode.Should().Be(ErrorCode.DatabaseError);
     }
 
     [Test]
@@ -56,11 +58,11 @@ public class LogInUnitTests
         //Arrange
 
         //Act
-        string? result = await _authenticationDataAccess.LogInAsync("konstantinos", "falsePassword")!;
+        AuthenticationResult? result = await _authenticationDataAccess.LogInAsync("konstantinos", "falsePassword")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().Be("InvalidCredentials");
+        result.ErrorCode.Should().Be(ErrorCode.InvalidCredentials);
     }
 
     [Test]
@@ -69,13 +71,13 @@ public class LogInUnitTests
         //Arrange
 
         //Act
-        string? result = await _authenticationDataAccess.LogInAsync("konstantinos", "password")!;
+        AuthenticationResult? result = await _authenticationDataAccess.LogInAsync("konstantinos", "password")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().NotBe("DatabaseError");
-        result.Should().NotBe("InvalidCredentials");
-        result.Length.Should().BeGreaterThan(30);    
+        result.ErrorCode.Should().Be(ErrorCode.None);
+        result.Token!.Should().NotBeNull();
+        result.Token!.Length.Should().BeGreaterThan(30);
     }
 
     [TearDown]

--- a/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/SignUpUnitTests.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/SignUpUnitTests.cs
@@ -2,6 +2,7 @@ using FluentAssertions;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
+using TodoAPIAssignment.AuthenticationLibrary.Enums;
 using TodoAPIAssignment.AuthenticationLibrary.Models;
 
 namespace TodoAPIAssignment.AuthenticationLibrary.Tests.UnitTests;
@@ -35,11 +36,11 @@ public class SignUpUnitTests
         //missing configuration causes the test to fail. This is 1 way to get to the exception
 
         //Act
-        string? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
+        AuthenticationResult? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().Be("DatabaseError");
+        result.ErrorCode.Should().Be(ErrorCode.DatabaseError);
     }
 
     [Test]
@@ -51,11 +52,11 @@ public class SignUpUnitTests
         await _authDbContext.SaveChangesAsync();
 
         //Act
-        string? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "giannis@gmail.com")!;
+        AuthenticationResult? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "giannis@gmail.com")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().Be("DuplicateUsernameError");
+        result.ErrorCode.Should().Be(ErrorCode.DuplicateUsername);
     }
 
     [Test]
@@ -67,11 +68,11 @@ public class SignUpUnitTests
         await _authDbContext.SaveChangesAsync();
 
         //Act
-        string? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
+        AuthenticationResult? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
 
         //Assert
         result.Should().NotBeNull();
-        result.Should().Be("DuplicateEmailError");
+        result.ErrorCode.Should().Be(ErrorCode.DuplicateEmail);
     }
 
     [Test]
@@ -83,12 +84,14 @@ public class SignUpUnitTests
         _config["Jwt:Audience"].Returns("TodoAPIAssignment.API");
 
         //Act
-        string? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
+        AuthenticationResult? result = await _authenticationDataAccess.SignUpAsync("konstantinos", "password", "kinnaskonstantinos0@gmail.com")!;
 
         //Assert
         result.Should().NotBeNull();
         _authDbContext.Users.Should().HaveCount(1);
-        result.Should().NotContain("Error");
+        result.ErrorCode.Should().Be(ErrorCode.None);
+        result.Token.Should().NotBeNull();
+        result.Token!.Length.Should().BeGreaterThan(30);
     }
 
     [TearDown]

--- a/TodoAPIAssignment.AuthenticationLibrary/Enums/AuthenticationEnums.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary/Enums/AuthenticationEnums.cs
@@ -1,0 +1,10 @@
+﻿namespace TodoAPIAssignment.AuthenticationLibrary.Enums;
+
+public enum ErrorCode
+{
+    None = 0,
+    DatabaseError = 1,
+    DuplicateUsername = 2,
+    DuplicateEmail = 3,
+    InvalidCredentials = 4
+}

--- a/TodoAPIAssignment.AuthenticationLibrary/IAuthenticationDataAccess.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary/IAuthenticationDataAccess.cs
@@ -1,8 +1,9 @@
-﻿
+﻿using TodoAPIAssignment.AuthenticationLibrary.Models;
+
 namespace TodoAPIAssignment.AuthenticationLibrary;
 
 public interface IAuthenticationDataAccess
 {
-    Task<string>? LogInAsync(string username, string password);
-    Task<string>? SignUpAsync(string username, string password, string email);
+    Task<AuthenticationResult>? LogInAsync(string username, string password);
+    Task<AuthenticationResult>? SignUpAsync(string username, string password, string email);
 }

--- a/TodoAPIAssignment.AuthenticationLibrary/Models/AuthenticationResult.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary/Models/AuthenticationResult.cs
@@ -1,0 +1,9 @@
+﻿using TodoAPIAssignment.AuthenticationLibrary.Enums;
+
+namespace TodoAPIAssignment.AuthenticationLibrary.Models;
+
+public class AuthenticationResult
+{
+    public string? Token { get; set; }
+    public ErrorCode ErrorCode { get; set; }
+}


### PR DESCRIPTION
I added enough integration tests to check a possible user log in after a user sign up. I also refactored the authentication library code, which means that now instead of strings the Login and SignUp methods return AuthenticationResult, which contains an enum that contains any possible errors. This way code mantainability will hopefully become much simpler.