### PR TITLE
Added Implementation For Log Out

### DIFF
--- a/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/LogOutUnitTests.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary.Tests/UnitTests/LogOutUnitTests.cs
@@ -1,6 +1,9 @@
-﻿using Microsoft.EntityFrameworkCore;
+﻿using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using NSubstitute;
+using NSubstitute.ReturnsExtensions;
+using TodoAPIAssignment.AuthenticationLibrary.Enums;
 
 namespace TodoAPIAssignment.AuthenticationLibrary.Tests.UnitTests;
 
@@ -36,20 +39,55 @@ public class LogOutUnitTests
     [Test]
     public async Task LogOut_ShouldFailAndReturnErrorMessage_IfConfigurationNotSet()
     {
-        Assert.Fail();
+        //Arrange
+        _config["Jwt:Key"].ReturnsNull();
+        _config["Jwt:Issuer"].ReturnsNull();
+        _config["Jwt:Audience"].ReturnsNull();
+
+        //Act
+        ErrorCode result = await _authenticationDataAccess.LogOutAsync(_accessToken);
+
+        //Assert
+        result.Should().Be(ErrorCode.DatabaseError);
     }
 
     [Test]
     public async Task LogOut_ShouldFailAndReturnErrorMessage_IfInvalidAccessToken()
     {
-        Assert.Fail();
+        //Arrange
+
+        //Act
+        ErrorCode result = await _authenticationDataAccess.LogOutAsync("bogusToken");
+
+        //Assert
+        result.Should().Be(ErrorCode.InvalidAccessToken);
+    }
+
+    [Test]
+    public async Task LogOut_ShouldFailAndReturnErrorMessage_IfSameTokenIsUsedTwice()
+    {
+        //Arrange
+        await _authenticationDataAccess.LogOutAsync(_accessToken);
+
+        //Act
+        ErrorCode result = await _authenticationDataAccess.LogOutAsync(_accessToken);
+
+        //Assert
+        result.Should().Be(ErrorCode.InvalidAccessToken);
     }
 
     [Test]
     public async Task LogOut_ShouldSucceedAndUpdateTokenCounter()
     {
-        Assert.Fail();
+        //Arrange
+
+        //Act
+        ErrorCode result = await _authenticationDataAccess.LogOutAsync(_accessToken);
+
+        //Assert
+        result.Should().Be(ErrorCode.None);
     }
+    
 
     [TearDown]
     public void TearDown() 

--- a/TodoAPIAssignment.AuthenticationLibrary/Enums/AuthenticationEnums.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary/Enums/AuthenticationEnums.cs
@@ -6,5 +6,6 @@ public enum ErrorCode
     DatabaseError = 1,
     DuplicateUsername = 2,
     DuplicateEmail = 3,
-    InvalidCredentials = 4
+    InvalidCredentials = 4,
+    InvalidAccessToken = 5
 }

--- a/TodoAPIAssignment.AuthenticationLibrary/IAuthenticationDataAccess.cs
+++ b/TodoAPIAssignment.AuthenticationLibrary/IAuthenticationDataAccess.cs
@@ -1,9 +1,12 @@
-﻿using TodoAPIAssignment.AuthenticationLibrary.Models;
+﻿using TodoAPIAssignment.AuthenticationLibrary.Enums;
+using TodoAPIAssignment.AuthenticationLibrary.Models;
 
 namespace TodoAPIAssignment.AuthenticationLibrary;
 
 public interface IAuthenticationDataAccess
 {
+    Task<AppUser?> CheckAndDecodeAccessTokenAsync(string accessToken);
     Task<AuthenticationResult>? LogInAsync(string username, string password);
+    Task<ErrorCode> LogOutAsync(string accessToken);
     Task<AuthenticationResult>? SignUpAsync(string username, string password, string email);
 }


### PR DESCRIPTION
Added a basic implementation for log out. This implementation first validates and decodes the token to make sure the user can log out. Once that is done all the existing tokens are put in a blacklist by incrementing by 1 the user specific counter that exists in the database(each user has 1 once registered). Because in the validation there is a check that checks that specific field all previous tokens with the previous counter number will fail if used to access any resources of the REST API after a logout process has occured. After some thought I also added an extra test that checks for this very specific case, which passes(the other 3 pass too) and thus confirms that this implementation works.