### PR TITLE
Added LogOut API Endpoint

### DIFF
--- a/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
+++ b/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
@@ -55,4 +55,23 @@ public class AuthenticationController : ControllerBase
             return StatusCode(500, new { ErrorMessage = "InternalServerError" }); ;
         }
     }
+
+    [HttpPost("LogOut")]
+    public async Task<IActionResult> LogOut([FromBody] LogOutRequestModel logOutRequestModel)
+    {
+        try
+        {
+            ErrorCode errorCode = await _authenticationDataAccess.LogOutAsync(logOutRequestModel.Token!)!;
+
+            if (errorCode == ErrorCode.InvalidAccessToken)
+                return BadRequest(new { ErrorMessage = "InvalidAccessToken" });
+
+            return Ok();
+        }
+        catch (Exception)
+        {
+            return StatusCode(500, new { ErrorMessage = "InternalServerError" }); ;
+        }
+    }
+
 }

--- a/TodoAPIAssignment.API/Models/RequestModels/LogOutRequestModel.cs
+++ b/TodoAPIAssignment.API/Models/RequestModels/LogOutRequestModel.cs
@@ -1,0 +1,9 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace TodoAPIAssignment.API.Models.RequestModels;
+
+public class LogOutRequestModel
+{
+    [Required]
+    public string? Token { get; set; }
+}


### PR DESCRIPTION
I added a log out API endpoint that allows the user to logout, which means that this token will become useless for subsequent API calls. This endpoint also returns appropriate status codes for different errors that might occur.