### PR TITLE
Changed The Transfer Method Of The Access Token

### DIFF
--- a/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/AuthenticationControllerTests.cs
+++ b/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/AuthenticationControllerTests.cs
@@ -1,6 +1,7 @@
 ﻿using FluentAssertions;
 using Microsoft.AspNetCore.Mvc.Testing;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using TodoAPIAssignement.API.Tests.IntegrationTests.HelperMethods;
@@ -140,13 +141,10 @@ public class AuthenticationControllerTests
     public async Task LogOut_ShouldFailAndReturnBadRequest_IfInvalidAccessToken()
     {
         //Arrange
-        LogOutRequestModel logOutRequestModel = new LogOutRequestModel()
-        {
-            Token = "bogusToken"
-        };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "bogusToken");
 
         //Act
-        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", logOutRequestModel);
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", new {});
         string? errorMessageValue = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
 
         //Assert
@@ -159,14 +157,11 @@ public class AuthenticationControllerTests
     public async Task LogOut_ShouldLogOutUserAndReturnOk()
     {
         //Arrange
-        LogOutRequestModel logOutRequestModel = new LogOutRequestModel()
-        {
-            Token = _accessToken
-        };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
 
         //Act
-        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", logOutRequestModel);
-
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", new {});
+         
         //Assert
         response.StatusCode.Should().Be(HttpStatusCode.OK);
     }
@@ -175,13 +170,10 @@ public class AuthenticationControllerTests
     public async Task LogOut_ShouldFailAndReturnBadRequest_IfSameAccessTokenIsUsedAfterLogOut()
     {
         //Arrange
-        LogOutRequestModel logOutRequestModel = new LogOutRequestModel()
-        {
-            Token = _accessToken
-        };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
 
         //Act
-        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", logOutRequestModel);
+        HttpResponseMessage response = await httpClient.PostAsJsonAsync("/api/authentication/logout", new {});
         string? errorMessageValue = await JsonParsingHelperMethods.GetSingleStringValueFromBody(response, "errorMessage");
 
         //Assert

--- a/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/TodosControllerTests.cs
+++ b/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/TodosControllerTests.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using System.Net;
+using System.Net.Http.Headers;
 using System.Net.Http.Json;
 using System.Text.Json;
 using TodoAPIAssignement.API.Tests.IntegrationTests.HelperMethods;
@@ -51,8 +52,8 @@ internal class TodosControllerTests
         {
             Title = "MyTodo",
             IsDone = false,
-            Token = "BogusToken"
         };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", "BogusToken");
 
         //Act
         HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/todos/", createTodoRequestModel);
@@ -72,8 +73,8 @@ internal class TodosControllerTests
         {
             Title = "MyTodo",
             IsDone = false,
-            Token = _accessToken
         };
+        httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", _accessToken);
 
         //Act
         HttpResponseMessage response = await httpClient.PostAsJsonAsync("api/todos/", createTodoRequestModel);

--- a/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
+++ b/TodoAPIAssignment.API/Controllers/AuthenticationController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using TodoAPIAssignment.API.Models.AuthenticationControllerModels.RequestModels;
 using TodoAPIAssignment.AuthenticationLibrary;
 using TodoAPIAssignment.AuthenticationLibrary.Enums;
@@ -57,11 +58,17 @@ public class AuthenticationController : ControllerBase
     }
 
     [HttpPost("LogOut")]
-    public async Task<IActionResult> LogOut([FromBody] LogOutRequestModel logOutRequestModel)
+    public async Task<IActionResult> LogOut()
     {
         try
         {
-            ErrorCode errorCode = await _authenticationDataAccess.LogOutAsync(logOutRequestModel.Token!)!;
+            string authorizationHeader = Request.Headers["Authorization"]!;
+            if(authorizationHeader.IsNullOrEmpty() || !authorizationHeader.StartsWith("Bearer "))
+                return BadRequest(new { ErrorMessage = "InvalidAccessToken" });
+
+            string token = authorizationHeader.Substring("Bearer ".Length).Trim();
+
+            ErrorCode errorCode = await _authenticationDataAccess.LogOutAsync(token)!;
 
             if (errorCode == ErrorCode.InvalidAccessToken)
                 return BadRequest(new { ErrorMessage = "InvalidAccessToken" });

--- a/TodoAPIAssignment.API/Controllers/TodosController.cs
+++ b/TodoAPIAssignment.API/Controllers/TodosController.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
 using TodoAPIAssignment.API.Models.TodoControllerModels.RequestModels;
 using TodoAPIAssignment.AuthenticationLibrary;
 using TodoAPIAssignment.AuthenticationLibrary.Models;
@@ -25,7 +26,13 @@ public class TodosController : ControllerBase
     {
         try
         {
-            AppUser? appUser = await _authenticationDataAccess.CheckAndDecodeAccessTokenAsync(createTodoRequestModel.Token!);
+            string authorizationHeader = Request.Headers["Authorization"]!;
+            if (authorizationHeader.IsNullOrEmpty() || !authorizationHeader.StartsWith("Bearer "))
+                return BadRequest(new { ErrorMessage = "InvalidAccessToken" });
+
+            string token = authorizationHeader.Substring("Bearer ".Length).Trim(); //Or substring 7, this just removes the Bearer word from the token
+
+            AppUser? appUser = await _authenticationDataAccess.CheckAndDecodeAccessTokenAsync(token);
             if(appUser is null)
                 return BadRequest(new { ErrorMessage = "InvalidAccessToken" });
 

--- a/TodoAPIAssignment.API/Models/AuthenticationControllerModels/RequestModels/LogOutRequestModel.cs
+++ b/TodoAPIAssignment.API/Models/AuthenticationControllerModels/RequestModels/LogOutRequestModel.cs
@@ -1,9 +1,0 @@
-﻿using System.ComponentModel.DataAnnotations;
-
-namespace TodoAPIAssignment.API.Models.AuthenticationControllerModels.RequestModels;
-
-public class LogOutRequestModel
-{
-    [Required]
-    public string? Token { get; set; }
-}

--- a/TodoAPIAssignment.API/Models/TodoControllerModels/RequestModels/CreateTodoRequestModel.cs
+++ b/TodoAPIAssignment.API/Models/TodoControllerModels/RequestModels/CreateTodoRequestModel.cs
@@ -7,6 +7,4 @@ public class CreateTodoRequestModel
     [Required]
     public string? Title { get; set; }
     public bool IsDone { get; set; }
-    [Required]
-    public string? Token { get; set; }
 }


### PR DESCRIPTION
From this update on the access token will be transferred correctly using the authorization header and not the body(for the logout and the createTodo endpoint). This will be the future behaviour for the rest of the endpoints that will subsequently be implemented.