### PR TITLE
Added Failing Unit Tests For Get Todos Functionality

### DIFF
--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/GetTodosUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/GetTodosUnitTests.cs
@@ -1,0 +1,42 @@
+﻿using Microsoft.EntityFrameworkCore;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+
+[TestFixture]
+[Category("Unit")]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+[Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
+public class GetTodosUnitTests
+{
+    private DataDbContext _dataDbContext;
+    private TodoDataAccess _todoDataAccess;
+
+    [SetUp]
+    public void Setup()
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+        .Options;
+
+        _dataDbContext = new DataDbContext(options);
+        _todoDataAccess = new TodoDataAccess(_dataDbContext);
+    }
+
+    [Test]
+    public async Task GetTodos_ShouldSucceedAndReturnNoTodos_IfUserHasNone()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task GetTodos_ShouldSucceedAndReturnTodos()
+    {
+        Assert.Fail();
+    }
+
+}


### PR DESCRIPTION
I added 2 unit tests that test the basic flow of the GetTodos method. In general it will either return no todos, because the user has none or it will return the todos if user have some. As before I am not going to test the exception, because the in memory database makes it too difficult to do so.