### PR TITLE
Added Failing Unit Tests For Update Todo Functionality

### DIFF
--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/UpdateTodoUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/UpdateTodoUnitTests.cs
@@ -1,0 +1,48 @@
+﻿using Microsoft.EntityFrameworkCore;
+
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+
+[TestFixture]
+[Category("Unit")]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+[Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
+public class UpdateTodoUnitTests
+{
+    private TodoDataAccess _todoDataAccess;
+    private DataDbContext _dataDbContext;
+
+    [SetUp]
+    public void SetUp()
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+        .Options;
+
+        _dataDbContext = new DataDbContext(options);
+        _todoDataAccess = new TodoDataAccess(_dataDbContext);
+    }
+
+    [Test]
+    public async Task UpdateTodo_ShouldReturnNull_IfTodoNotFound()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task UpdateTodo_ShouldReturnNull_IfTodoExistsButUserDoesNotOwnIt()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task UpdateTodo_ShouldSucceedAndUpdateTodo()
+    {
+        Assert.Fail();
+    }
+
+    [TearDown]
+    public void TearDown() 
+    { 
+    
+    }
+}


### PR DESCRIPTION
I added 3 unit tests that are pretty similar to the get todo by id unit tests. The first 2 check the scenario in which the todo does not exist or the user does not own that todo and the third test the success case. The delete todo unit tests will probably be pretty similar to those.