### PR TITLE
Added Integration Tests For DeleteTodo Endpoint

### DIFF
--- a/TodoAPIAssignment.API/Controllers/TodosController.cs
+++ b/TodoAPIAssignment.API/Controllers/TodosController.cs
@@ -46,9 +46,8 @@ public class TodosController : ControllerBase
             if(createTodoResult.ErrorCode == ErrorCode.DatabaseError)                
                 return StatusCode(500, new { ErrorMessage = "InternalServerError" });
 
-            //TODO change that when I create the getTodoById method
-            var locationUri = $"https://localhost:7279/api/todos/{createTodoResult.Todo!.Id}";
-            return Created(locationUri, createTodoResult.Todo);
+            //, 
+            return CreatedAtAction(nameof(GetTodo), new { todoId = createTodoResult.Todo!.Id }, createTodoResult.Todo);
         }
         catch (Exception)
         {


### PR DESCRIPTION
I added 3 integration tests for the delete todo endpoint, which are pretty similar to the integration tests of the GetTodo endpoint and of the UpdateTodo endpoint. The first 2 check for the typical error cases, which are the todo not existing or the user not owning the todo and the third test as usual checks the success case, in which the todo should be deleted. I also refactored the create todo endpoint, which now creates the location of the newly created todo dynamically(no longer localhost stuff).