### PR TITLE
Added Failing Unit Tests For The Create Todo Item Functionality

### DIFF
--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/CreateTodoItemUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/CreateTodoItemUnitTests.cs
@@ -1,0 +1,53 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TodoAPIAssignment.DataAccessLibrary.Models;
+
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoItemUnitTests;
+
+[TestFixture]
+[Category("Unit")]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+[Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
+public class CreateTodoItemUnitTests
+{
+    private TodoDataAccess _todoDataAccess;
+    private DataDbContext _dataDbContext;
+    private Todo _testTodo;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+        .Options;
+
+
+        _dataDbContext = new DataDbContext(options);
+        _todoDataAccess = new TodoDataAccess(_dataDbContext);
+        CreateTodoResult result = await _todoDataAccess.CreateTodoAsync(new Todo() { Title = "MyTodo", IsDone = false, UserId = "1" });
+        _testTodo = result.Todo!;
+    }
+
+    [Test]
+    public async Task CreateTodoItem_ShouldReturnNullAndTodoNotFoundError_IfTodoNotFound()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task CreateTodoItem_ShouldReturnNullAndTodoNotFoundError_IfTodoExistsButUserDoesNotOwnTodo()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task CreateTodoItem_ShouldSucceedAndCreateTodoItem()
+    {
+        Assert.Fail();
+    }
+
+    [TearDown]
+    public void TearDown() 
+    { 
+    
+    }
+}

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/CreateTodoUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/CreateTodoUnitTests.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 
-namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoUnitTests;
 
 [TestFixture]
 [Category("Unit")]
@@ -47,8 +47,8 @@ public class CreateTodoUnitTests
     }
 
     [TearDown]
-    public void TearDown() 
-    { 
-    
+    public void TearDown()
+    {
+
     }
 }

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/DeleteTodoUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/DeleteTodoUnitTests.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 
-namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoUnitTests;
 
 [TestFixture]
 [Category("Unit")]
@@ -70,8 +70,8 @@ public class DeleteTodoUnitTests
     }
 
     [TearDown]
-    public void TearDown() 
-    { 
-    
+    public void TearDown()
+    {
+
     }
 }

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/GetTodoByIdUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/GetTodoByIdUnitTests.cs
@@ -3,16 +3,16 @@ using Microsoft.EntityFrameworkCore;
 using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 
-namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoUnitTests;
 
 [TestFixture]
 [Category("Unit")]
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
-public class UpdateTodoUnitTests
+public class GetTodoByIdUnitTests
 {
-    private TodoDataAccess _todoDataAccess;
     private DataDbContext _dataDbContext;
+    private TodoDataAccess _todoDataAccess;
     private Todo _testTodo;
 
     [SetUp]
@@ -24,24 +24,20 @@ public class UpdateTodoUnitTests
 
         _dataDbContext = new DataDbContext(options);
         _todoDataAccess = new TodoDataAccess(_dataDbContext);
+
         CreateTodoResult result = await _todoDataAccess.CreateTodoAsync(new Todo() { Title = "MyTodo", IsDone = false, UserId = "1" });
         _testTodo = result.Todo!;
     }
 
     [Test]
-    public async Task UpdateTodo_ShouldReturnNullAndNotFoundError_IfTodoNotFound()
+    public async Task GetTodoById_ShouldReturnNullAndNotFoundMessage_IfTodoNotFound()
     {
         //Arrange
-        Todo updatedTodo = new Todo()
-        {
-            Id = "bogusTodoId",
-            Title = "updatedTitle",
-            IsDone = true,
-            UserId = "1"
-        };
+        string bogusTodoId = "bogusTodoId";
+        string userId = "1";
 
         //Act
-        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
+        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(userId, bogusTodoId);
 
         //Assert
         result.Should().NotBeNull();
@@ -50,19 +46,14 @@ public class UpdateTodoUnitTests
     }
 
     [Test]
-    public async Task UpdateTodo_ShouldReturnNullAndNotFoundError_IfTodoExistsButUserDoesNotOwnIt()
+    public async Task GetTodoById_ShouldReturnNullAndNotFoundMessage_IfTodoExistsButUserDoesNotOwnIt()
     {
         //Arrange
-        Todo updatedTodo = new Todo()
-        {
-            Id = _testTodo.Id,
-            Title = "updatedTitle",
-            IsDone = true,
-            UserId = "bogusUserId"
-        };
+        string todoId = _testTodo!.Id!;
+        string bogusUserId = "bogusUserId";
 
         //Act
-        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
+        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(bogusUserId, todoId);
 
         //Assert
         result.Should().NotBeNull();
@@ -71,32 +62,26 @@ public class UpdateTodoUnitTests
     }
 
     [Test]
-    public async Task UpdateTodo_ShouldSucceedAndUpdateTodo()
+    public async Task GetTodoById_ShouldReturnTodo()
     {
         //Arrange
-        string updatedTitle = "updatedTitle";
-        Todo updatedTodo = new Todo()
-        {
-            Id = _testTodo.Id,
-            Title = updatedTitle,
-            IsDone = true,
-            UserId = _testTodo.UserId
-        };
+        string todoId = _testTodo!.Id!;
+        string userId = "1";
 
         //Act
-        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
+        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(userId, todoId);
 
         //Assert
         result.Should().NotBeNull();
         result.ErrorCode.Should().Be(ErrorCode.None);
         result.Todo.Should().NotBeNull();
-        result.Todo!.UserId.Should().Be(_testTodo.UserId);
-        result.Todo!.Title.Should().Be(updatedTitle);
+        result!.Todo!.Id.Should().Be(todoId);
+        result!.Todo!.UserId.Should().Be(userId);
     }
 
     [TearDown]
-    public void TearDown() 
-    { 
-    
+    public void TearDown()
+    {
+
     }
 }

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/GetTodosUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/GetTodosUnitTests.cs
@@ -3,7 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 
-namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoUnitTests;
 
 [TestFixture]
 [Category("Unit")]

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/UpdateTodoUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoUnitTests/UpdateTodoUnitTests.cs
@@ -3,16 +3,16 @@ using Microsoft.EntityFrameworkCore;
 using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 
-namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests;
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoUnitTests;
 
 [TestFixture]
 [Category("Unit")]
 [FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
 [Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
-public class GetTodoByIdUnitTests
+public class UpdateTodoUnitTests
 {
-    private DataDbContext _dataDbContext;
     private TodoDataAccess _todoDataAccess;
+    private DataDbContext _dataDbContext;
     private Todo _testTodo;
 
     [SetUp]
@@ -24,20 +24,24 @@ public class GetTodoByIdUnitTests
 
         _dataDbContext = new DataDbContext(options);
         _todoDataAccess = new TodoDataAccess(_dataDbContext);
-
         CreateTodoResult result = await _todoDataAccess.CreateTodoAsync(new Todo() { Title = "MyTodo", IsDone = false, UserId = "1" });
         _testTodo = result.Todo!;
     }
 
     [Test]
-    public async Task GetTodoById_ShouldReturnNullAndNotFoundMessage_IfTodoNotFound()
+    public async Task UpdateTodo_ShouldReturnNullAndNotFoundError_IfTodoNotFound()
     {
         //Arrange
-        string bogusTodoId = "bogusTodoId";
-        string userId = "1";
+        Todo updatedTodo = new Todo()
+        {
+            Id = "bogusTodoId",
+            Title = "updatedTitle",
+            IsDone = true,
+            UserId = "1"
+        };
 
         //Act
-        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(userId, bogusTodoId);
+        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
 
         //Assert
         result.Should().NotBeNull();
@@ -46,14 +50,19 @@ public class GetTodoByIdUnitTests
     }
 
     [Test]
-    public async Task GetTodoById_ShouldReturnNullAndNotFoundMessage_IfTodoExistsButUserDoesNotOwnIt()
+    public async Task UpdateTodo_ShouldReturnNullAndNotFoundError_IfTodoExistsButUserDoesNotOwnIt()
     {
         //Arrange
-        string todoId = _testTodo!.Id!;
-        string bogusUserId = "bogusUserId";
+        Todo updatedTodo = new Todo()
+        {
+            Id = _testTodo.Id,
+            Title = "updatedTitle",
+            IsDone = true,
+            UserId = "bogusUserId"
+        };
 
         //Act
-        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(bogusUserId, todoId);
+        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
 
         //Assert
         result.Should().NotBeNull();
@@ -62,21 +71,27 @@ public class GetTodoByIdUnitTests
     }
 
     [Test]
-    public async Task GetTodoById_ShouldReturnTodo()
+    public async Task UpdateTodo_ShouldSucceedAndUpdateTodo()
     {
         //Arrange
-        string todoId = _testTodo!.Id!;
-        string userId = "1";
+        string updatedTitle = "updatedTitle";
+        Todo updatedTodo = new Todo()
+        {
+            Id = _testTodo.Id,
+            Title = updatedTitle,
+            IsDone = true,
+            UserId = _testTodo.UserId
+        };
 
         //Act
-        GetTodoResult result = await _todoDataAccess.GetUserTodoAsync(userId, todoId);
+        UpdateTodoResult result = await _todoDataAccess.UpdateUserTodoAsync(updatedTodo);
 
         //Assert
         result.Should().NotBeNull();
         result.ErrorCode.Should().Be(ErrorCode.None);
         result.Todo.Should().NotBeNull();
-        result!.Todo!.Id.Should().Be(todoId);
-        result!.Todo!.UserId.Should().Be(userId);
+        result.Todo!.UserId.Should().Be(_testTodo.UserId);
+        result.Todo!.Title.Should().Be(updatedTitle);
     }
 
     [TearDown]


### PR DESCRIPTION
I added 3 failing unit tests for the create todo functionality of the DataAccessLibrary. Because the todo item depends on its todo "parent", the first 2 tests check the case in which either the todo does not exist or the user does not own the todo. The third test checks the success case, in which the todo item should be created.