### PR TITLE
Added Failing Unit Tests For Get Todo Item By Id Functionality

### DIFF
--- a/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/TodoItemsControllerTests.cs
+++ b/TodoAPIAssignement.API.Tests/IntegrationTests/ControllerTests/TodoItemsControllerTests.cs
@@ -91,7 +91,7 @@ public class TodoItemsControllerTests
     }
 
     [Test, Order(3)]
-    public async Task CreateTodo_ShouldSucceedAndReturnTodoAndLocation()
+    public async Task CreateTodoItem_ShouldSucceedAndReturnTodoItemAndLocation()
     {
         //Arrange
         CreateTodoItemRequestModel createTodoRequestModel = new CreateTodoItemRequestModel()

--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/GetTodoItemByIdUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/GetTodoItemByIdUnitTests.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.EntityFrameworkCore;
+using TodoAPIAssignment.DataAccessLibrary.Models.Results.TodoResults;
+using TodoAPIAssignment.DataAccessLibrary.Models;
+using FluentAssertions;
+using TodoAPIAssignment.DataAccessLibrary.Enums;
+
+namespace TodoAPIAssignment.DataAccessLibrary.Tests.UnitTests.TodoItemUnitTests;
+
+[TestFixture]
+[Category("Unit")]
+[FixtureLifeCycle(LifeCycle.InstancePerTestCase)]
+[Author("konstantinos", "kinnaskonstantinos0@gmail.com")]
+
+public class GetTodoItemByIdUnitTests
+{
+    private DataDbContext _dataDbContext;
+    private TodoDataAccess _todoDataAccess;
+    private Todo _testTodo;
+
+    [SetUp]
+    public async Task SetUp()
+    {
+        var options = new DbContextOptionsBuilder<DataDbContext>()
+        .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
+        .Options;
+
+        _dataDbContext = new DataDbContext(options);
+        _todoDataAccess = new TodoDataAccess(_dataDbContext);
+
+        CreateTodoResult result = await _todoDataAccess.CreateTodoAsync(new Todo() { Title = "MyTodo", IsDone = false, UserId = "1" });
+        _testTodo = result.Todo!;
+    }
+
+    [Test]
+    public async Task GetTodoItemById_ShouldReturnNullAndNotFoundTodoMessage_IfTodoNotFound()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task GetTodoItemById_ShouldReturnNullAndNotFoundTodoMessage_IfTodoExistsButUserDoesNotOwnIt()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task GetTodoItemById_ShouldReturnNullAndNotFoundTodoItemMessage_IfTodoExistsButTodoItemDoesNotExist()
+    {
+        Assert.Fail();
+    }
+
+    [Test]
+    public async Task GetTodoItemById_ShouldReturnTodoItem()
+    {
+        Assert.Fail();
+    }
+
+    [TearDown]
+    public void TearDown()
+    {
+
+    }
+}


### PR DESCRIPTION
I added the 4 basic unit tests that test functionality of the Get UserTodoByItemAsync in the data access library. The 2 first tests check the failing cases in which the todo, that the todo item is part of, does not exists or/and the user does not have own. The third test is a bit different and tests the failing case, in which the todo does exist, but the todo item itself does not. Finally the fourth test check the success case, in which the todo item should be correctly returned.