### PR TITLE
Added Implementation For Update Todo Item

### DIFF
--- a/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/UpdateTodoItemUnitTests.cs
+++ b/TodoAPIAssignment.DataAccessLibrary.Tests/UnitTests/TodoItemUnitTests/UpdateTodoItemUnitTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using TodoAPIAssignment.DataAccessLibrary.Enums;
 using TodoAPIAssignment.DataAccessLibrary.Models;
 using TodoAPIAssignment.DataAccessLibrary.Models.Results.TodoItemResults;
 using TodoAPIAssignment.DataAccessLibrary.Models.Results.TodoResults;
@@ -46,25 +47,96 @@ public class UpdateTodoItemUnitTests
     [Test]
     public async Task UpdateTodoItem_ShouldReturnNullAndNotFoundTodoMessage_IfTodoNotFound()
     {
-        Assert.Fail();
+        //Arrange
+        string userId = "1";
+        string bogusTodoId = "bogusTodoId";
+        TodoItem updatedTodoItem = new TodoItem()
+        {
+            Id = _testTodoItem.Id!,
+            Title = "TodoItemUpdatedTitle",
+            Description = "Todo Item Updated Description",
+            IsDone = true
+        };
+
+        //Act
+        UpdateTodoItemResult result = await _todoItemDataAccess.UpdateUserTodoItemAsync(userId, bogusTodoId, updatedTodoItem);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.ErrorCode.Should().Be(ErrorCode.TodoNotFound);
+        result.TodoItem.Should().Be(null);
     }
 
     [Test]
     public async Task UpdateTodoItem_ShouldReturnNullAndNotFoundTodoMessage_IfTodoExistsButUserDoesNotOwnIt()
     {
-        Assert.Fail();
+        //Arrange
+        string bogusUserId = "bogusUserId";
+        string todoId = _testTodo.Id!;
+        TodoItem updatedTodoItem = new TodoItem()
+        {
+            Id = _testTodoItem.Id!,
+            Title = "TodoItemUpdatedTitle",
+            Description = "Todo Item Updated Description",
+            IsDone = true
+        };
+
+        //Act
+        UpdateTodoItemResult result = await _todoItemDataAccess.UpdateUserTodoItemAsync(bogusUserId, todoId, updatedTodoItem);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.ErrorCode.Should().Be(ErrorCode.TodoNotFound);
+        result.TodoItem.Should().Be(null);
+
     }
 
     [Test]
     public async Task UpdateTodoItem_ShouldReturnNullAndNotFoundTodoItemMessage_IfTodoExistsButTodoItemDoesNotExist()
     {
-        Assert.Fail();
+        //Arrange
+        string userId = "1";
+        string todoId = _testTodo.Id!;
+        TodoItem updatedTodoItem = new TodoItem()
+        {
+            Id = "bogusTodoItemId",
+            Title = "TodoItemUpdatedTitle",
+            Description = "Todo Item Updated Description",
+            IsDone = true
+        };
+
+        //Act
+        UpdateTodoItemResult result = await _todoItemDataAccess.UpdateUserTodoItemAsync(userId, todoId, updatedTodoItem);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.ErrorCode.Should().Be(ErrorCode.TodoItemNotFound);
+        result.TodoItem.Should().Be(null);
+
     }
 
     [Test]
     public async Task UpdateTodoItem_ShouldUpdateTheTodoItem()
     {
-        Assert.Fail();
+        //Arrange
+        string userId = "1";
+        string todoId = _testTodo.Id!;
+        TodoItem updatedTodoItem = new TodoItem()
+        {
+            Id = _testTodoItem.Id!,
+            Title = "TodoItemUpdatedTitle",
+            Description = "Todo Item Updated Description",
+            IsDone = true
+        };
+
+        //Act
+        UpdateTodoItemResult result = await _todoItemDataAccess.UpdateUserTodoItemAsync(userId, todoId, updatedTodoItem);
+
+        //Assert
+        result.Should().NotBeNull();
+        result.ErrorCode.Should().Be(ErrorCode.None);
+        result.TodoItem.Should().NotBeNull();
+        result.TodoItem!.Id.Should().Be(updatedTodoItem.Id);
     }
 
     [TearDown]

--- a/TodoAPIAssignment.DataAccessLibrary/Models/Results/TodoItemResults/UpdateTodoItemResult.cs
+++ b/TodoAPIAssignment.DataAccessLibrary/Models/Results/TodoItemResults/UpdateTodoItemResult.cs
@@ -1,0 +1,9 @@
+﻿using TodoAPIAssignment.DataAccessLibrary.Enums;
+
+namespace TodoAPIAssignment.DataAccessLibrary.Models.Results.TodoItemResults;
+
+public class UpdateTodoItemResult
+{
+    public TodoItem? TodoItem { get; set; }
+    public ErrorCode ErrorCode { get; set; }
+}

--- a/TodoAPIAssignment.DataAccessLibrary/TodoItemDataAccess.cs
+++ b/TodoAPIAssignment.DataAccessLibrary/TodoItemDataAccess.cs
@@ -61,4 +61,31 @@ public class TodoItemDataAccess : ITodoItemDataAccess
         }
     }
 
+    public async Task<UpdateTodoItemResult> UpdateUserTodoItemAsync(string userId, string todoId, TodoItem todoItem)
+    {
+        try
+        {
+            GetTodoItemResult getTodoItemResult = await GetUserTodoItemAsync(userId, todoId, todoItem.Id!);
+            if (getTodoItemResult.ErrorCode == ErrorCode.TodoNotFound)
+                return new UpdateTodoItemResult() { TodoItem = null, ErrorCode = ErrorCode.TodoNotFound };
+            else if (getTodoItemResult.ErrorCode == ErrorCode.TodoItemNotFound)
+                return new UpdateTodoItemResult() { TodoItem = null, ErrorCode = ErrorCode.TodoItemNotFound };
+            else if (getTodoItemResult.ErrorCode == ErrorCode.DatabaseError)
+                return new UpdateTodoItemResult() { TodoItem = null, ErrorCode = ErrorCode.DatabaseError };
+
+            TodoItem foundTodoItem = getTodoItemResult.TodoItem!;
+            foundTodoItem.Title = todoItem.Title;
+            foundTodoItem.Description = todoItem.Description is not null ? todoItem.Description : foundTodoItem.Description;
+            foundTodoItem.IsDone = todoItem.IsDone;
+
+            await _dataDbContext.SaveChangesAsync();
+
+            return new UpdateTodoItemResult() { ErrorCode = ErrorCode.None, TodoItem = foundTodoItem };
+        }
+        catch (Exception)
+        {
+            return new UpdateTodoItemResult() { ErrorCode = ErrorCode.DatabaseError, TodoItem = null };
+        }
+    }
+
 }


### PR DESCRIPTION
I added a basic implementation in the data access library that allows the user to update one of their todo items(Title, Description and IsDone fields) that exist inside one of their todos using the todo items id. Also the failing unit tests of the previous commit are now passing.